### PR TITLE
feat: Add x86_64 GDT initialization

### DIFF
--- a/kernel/kernel/arch/arch.cpp
+++ b/kernel/kernel/arch/arch.cpp
@@ -1,0 +1,18 @@
+#include <kernel/arch/arch.hpp>
+
+#include <kernel/config.hpp>
+
+#if NOS_ARCH_X86_64
+#include <kernel/arch/x86_64/gdt.hpp>
+#endif
+
+namespace NOS::Arch {
+
+void initialize()
+{
+#if NOS_ARCH_X86_64
+    X86_64::GDT::initialize();
+#endif
+}
+
+} // namespace NOS::Arch

--- a/kernel/kernel/arch/arch.hpp
+++ b/kernel/kernel/arch/arch.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace NOS::Arch {
+
+void initialize();
+
+} // namespace NOS::Arch

--- a/kernel/kernel/arch/x86_64/gdt.cpp
+++ b/kernel/kernel/arch/x86_64/gdt.cpp
@@ -1,74 +1,104 @@
-#include <kernel/arch/x86_64/cpu/gdt.hpp>
+#include <kernel/arch/x86_64/gdt.hpp>
 
-#include <kernel/arch/x86_64/cpu/tss.hpp>
-#include <ncxx/container/static-array.hpp>
-#include <ncxx/def.hpp>
+#include <ncxx/basic-types.hpp>
+#include <ncxx/preprocessor/packed.hpp>
 
-namespace NOS::Arch::GDT {
+namespace NOS::X86_64::GDT {
 
-namespace {
+namespace Data {
 
-// static TSS tss;
-
-struct NOS_PACKED Entry
+struct NOS_PACKED GDTR
 {
-    u16_t limit;
+    u16_t size;
+    u64_t offset;
+};
+
+struct NOS_PACKED GDTEntry
+{
+    u16_t limit0;
     u16_t base0;
     u8_t base1;
     u8_t access;
     u8_t granularity;
     u8_t base2;
 };
-/*
-struct NOS_PACKED Table
+
+struct NOS_PACKED TSSEntry
 {
-    Entry null{
-        .limit = 0,
-        .base0 = 0,
-        .base1 = 0,
-        .access = 0,
-        .granularity = 0,
-        .base2 = 0};
-
-    Entry kernelCode{
-        .limit = 0,
-        .base0 = 0,
-        .base1 = 0,
-        .access = 0b10011010,
-        .granularity = 0b00100000,
-        .base2 = 0};
-
-    Entry kernelData{
-        .limit = 0,
-        .base0 = 0,
-        .base1 = 0,
-        .access = 0b10010010,
-        .granularity = 0,
-        .base2 = 0};
-
-    Entry userCode{
-        .limit = 0,
-        .base0 = 0,
-        .base1 = 0,
-        .access = 0b11111010,
-        .granularity = 0b00100000,
-        .base2 = 0};
-
-    Entry userData{
-        .limit = 0,
-        .base0 = 0,
-        .base1 = 0,
-        .access = 0b11110010,
-        .granularity = 0,
-        .base2 = 0};
-
-    TSS::Entry tss;
+    u16_t length;
+    u16_t base0;
+    u8_t base1;
+    u8_t flags1;
+    u8_t flags2;
+    u8_t base2;
+    u32_t base3;
+    u32_t reserved;
 };
-*/
-} // namespace
+
+struct NOS_PACKED GDT
+{
+    GDTEntry null;
+    GDTEntry code;
+    GDTEntry data;
+    GDTEntry userCode;
+    GDTEntry userData;
+    TSSEntry tss;
+};
+
+struct NOS_PACKED TSS
+{
+    u32_t reserved0;
+    u64_t rsp[3];
+    u64_t reserved1;
+    u64_t ist[7];
+    u64_t reserved2;
+    u16_t reserved3;
+    u16_t iopboffset;
+};
+
+TSS tss;
+GDT gdt{
+    {0x0000, 0, 0, 0x00, 0x00, 0}, // Null
+    {0x0000, 0, 0, 0x9A, 0x20, 0}, // Code
+    {0x0000, 0, 0, 0x92, 0x00, 0}, // Data
+    {0x0000, 0, 0, 0xF2, 0x00, 0}, // User data
+    {0x0000, 0, 0, 0xFA, 0x20, 0}, // User code
+    {
+        sizeof(TSS),
+        static_cast<u16_t>(reinterpret_cast<uintptr_t>(&tss)),
+        static_cast<u8_t>(reinterpret_cast<uintptr_t>(&tss) >> 16),
+        0x89,
+        0x00,
+        static_cast<u8_t>(reinterpret_cast<uintptr_t>(&tss) >> 24),
+        static_cast<u32_t>(reinterpret_cast<uintptr_t>(&tss) >> 32),
+        0x00} // Tss
+};
+
+GDTR gdtr{
+    sizeof(GDT) - 1,
+    reinterpret_cast<uintptr_t>(&gdt),
+};
+
+} // namespace Data
 
 void initialize()
 {
+    asm volatile(
+        "lgdt %[gdtr]\n\t"
+        "mov %[dsel], %%ds \n\t"
+        "mov %[dsel], %%fs \n\t"
+        "mov %[dsel], %%gs \n\t"
+        "mov %[dsel], %%es \n\t"
+        "mov %[dsel], %%ss \n\t"
+        "push %[csel] \n\t"
+        "lea 1f(%%rip), %%rax \n\t"
+        "push %%rax \n\t"
+        ".byte 0x48, 0xCB \n"
+        "1:" ::[gdtr] "m"(Data::gdtr),
+        [dsel] "m"(Selector::Data),
+        [csel] "i"(Selector::Code)
+        : "rax", "memory");
+    asm volatile("ltr %0" ::"r"(static_cast<u16_t>(Selector::TSS)));
 }
 
-} // namespace NOS::Arch::GDT
+} // namespace NOS::X86_64::GDT

--- a/kernel/kernel/arch/x86_64/gdt.hpp
+++ b/kernel/kernel/arch/x86_64/gdt.hpp
@@ -1,5 +1,20 @@
 #pragma once
 
+#include <ncxx/basic-types.hpp>
+
 namespace NOS::X86_64::GDT {
+
+namespace Selector {
+
+inline constexpr u8_t Null = 0x00;
+inline constexpr u8_t Code = 0x08;
+inline constexpr u8_t Data = 0x10;
+inline constexpr u8_t UserCode = 0x18;
+inline constexpr u8_t UserData = 0x20;
+inline constexpr u8_t TSS = 0x28;
+
+} // namespace Selector
+
+void initialize();
 
 } // namespace NOS::X86_64::GDT

--- a/kernel/kernel/kernel.cpp
+++ b/kernel/kernel/kernel.cpp
@@ -1,5 +1,6 @@
 #include <kernel/kernel.hpp>
 
+#include <kernel/arch/arch.hpp>
 #include <kernel/drivers/serial.hpp>
 #include <kernel/lang/cxxabi.hpp>
 #include <kernel/utility/log.hpp>
@@ -14,6 +15,11 @@ void initialize()
 
     Log::info("\t - cxxabi");
     Lang::CxxAbi::init();
+
+    Log::info("\t - arch");
+    Arch::initialize();
+
+    Log::info("Kernel completed");
 }
 
 void run()

--- a/kernel/kernel/lang/ubsan.cpp
+++ b/kernel/kernel/lang/ubsan.cpp
@@ -166,7 +166,7 @@ void __ubsan_handle_type_mismatch_v1(NOS::UBSan::TypeMismatchData* data, NOS::ui
     {
         print("use of nullptr", data->location);
     }
-    else if (ptr & ((1 << data->alignment) - 1))
+    else if (ptr & (data->alignment - 1))
     {
         print("unaligned access", data->location);
     }

--- a/kernel/meson.build
+++ b/kernel/meson.build
@@ -1,4 +1,5 @@
 src = files(
+    'kernel/arch/arch.cpp',
     'kernel/debug/assert.cpp',
     'kernel/lang/cxxabi.cpp',
     'kernel/lang/ubsan.cpp',
@@ -12,8 +13,8 @@ src = files(
 # x86_64 specific files
 if arch == 'x86_64'
     src += files(
-#        'kernel/arch/x86_64/cpu/gdt.cpp',
-        'kernel/arch/x86_64/drivers/serial.cpp'
+        'kernel/arch/x86_64/drivers/serial.cpp',
+        'kernel/arch/x86_64/gdt.cpp'
     )
 endif
 

--- a/libs/ncxx/ncxx/concept/enumeration.hpp
+++ b/libs/ncxx/ncxx/concept/enumeration.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <ncxx/type-trait/is-enum.hpp>
+
+namespace NOS {
+
+template<typename T>
+concept Enumeration = IsEnumV<T>;
+
+} // namespace  NOS

--- a/libs/ncxx/ncxx/preprocessor/packed.hpp
+++ b/libs/ncxx/ncxx/preprocessor/packed.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#define NOS_PACKED [[gnu::packed]]

--- a/libs/ncxx/ncxx/string/format-to.hpp
+++ b/libs/ncxx/ncxx/string/format-to.hpp
@@ -173,7 +173,7 @@ void formatTo(TOut& out, StringView fmt, Span<FormatArgument> arguments)
                 }
 
                 ++i;
-                NOS_ASSERT(i != last, "Invalid format");
+                NOS_ASSERT(i <= last, "Invalid format");
             }
 
             // we should be at the end, otherwise the format is invalid

--- a/libs/ncxx/ncxx/string/format-to.test.cpp
+++ b/libs/ncxx/ncxx/string/format-to.test.cpp
@@ -203,4 +203,15 @@ TEST_CASE("formatTo - position", "[String]")
     CHECK(sv == "Format at 1: 22; at 2 24; at 0 42");
 }
 
+TEST_CASE("formatTo - finishing with {:PRESENTATION}", "[String]")
+{
+    Out out;
+
+    formatTo(out, "0x{:x}", 0xfefefefe);
+
+    StringView sv = out.view();
+
+    CHECK(sv == "0xfefefefe");
+}
+
 } // namespace NOS

--- a/libs/ncxx/ncxx/utility/to-underlying-type.hpp
+++ b/libs/ncxx/ncxx/utility/to-underlying-type.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <ncxx/concept/enumeration.hpp>
+#include <ncxx/type-trait/underlying-type.hpp>
+
+namespace NOS {
+
+constexpr auto toUnderlyingType(Enumeration auto value)
+{
+    return static_cast<UnderlyingTypeT<decltype(value)>>(value);
+}
+
+} // namespace NOS


### PR DESCRIPTION
This commit adds the necessary code to initialize the Global Descriptor Table (GDT) for the x86_64 architecture. The GDT is responsible for managing memory segmentation and access control. It includes the definition of GDT entries, TSS entry, and GDTR structure. The `initialize()` function sets up the GDT by loading it into memory using inline assembly instructions. Additionally, a new header file `gdt.hpp` is added to provide an interface for initializing the GDT.

Other changes in this commit include:
- Adding a new file `arch.cpp` that includes `arch.hpp`.
- Updating `kernel.cpp` to call `Arch::initialize()` during kernel initialization.
- Removing unused files and updating build configuration.

The commit also introduces some utility functions and concepts in the NCXX library:
- A concept called `Enumeration` is defined in `enumeration.hpp`, which checks if a type is an enumeration.
- A macro called `NOS_PACKED` is defined in `packed.hpp`, which applies GCC's packed attribute to a struct or class.
- A function template called `toUnderlyingType()` is defined in `to-underlying-type.hpp`, which converts an enumeration value to its underlying integral type.
