### PR TITLE
Rudimentary IDT implementation

### DIFF
--- a/kernel/kernel/arch/arch.cpp
+++ b/kernel/kernel/arch/arch.cpp
@@ -2,9 +2,11 @@
 
 #include <kernel/config.hpp>
 
+#include <kernel/utility/log.hpp>
+
 #if NOS_ARCH_X86_64
-#include "kernel/utility/log.hpp"
 #include <kernel/arch/x86_64/gdt.hpp>
+#include <kernel/arch/x86_64/idt.hpp>
 #endif
 
 namespace NOS::Arch {
@@ -16,6 +18,7 @@ void initialize()
 
 #if NOS_ARCH_X86_64
     X86_64::GDT::initialize();
+    X86_64::IDT::initialize();
 #endif
 }
 

--- a/kernel/kernel/arch/x86_64/cpu-registers-push-pop.inc
+++ b/kernel/kernel/arch/x86_64/cpu-registers-push-pop.inc
@@ -1,0 +1,37 @@
+.intel_syntax noprefix
+
+.macro pushall
+    push rax
+    push rbx
+    push rcx
+    push rdx
+    push rsi
+    push rdi
+    push rbp
+    push r8
+    push r9
+    push r10
+    push r11
+    push r12
+    push r13
+    push r14
+    push r15
+.endm
+
+.macro popall
+    pop r15
+    pop r14
+    pop r13
+    pop r12
+    pop r11
+    pop r10
+    pop r9
+    pop r8
+    pop rbp
+    pop rdi
+    pop rsi
+    pop rdx
+    pop rcx
+    pop rbx
+    pop rax
+.endm

--- a/kernel/kernel/arch/x86_64/cpu.hpp
+++ b/kernel/kernel/arch/x86_64/cpu.hpp
@@ -1,6 +1,16 @@
 #pragma once
 
+#include <ncxx/basic-types.hpp>
+#include <ncxx/preprocessor/packed.hpp>
+
 namespace NOS::X86_64::CPU {
+
+struct NOS_PACKED Registers
+{
+    u64_t r15, r14, r13, r12, r11, r10, r9, r8;
+    u64_t rbp, rdi, rsi, rdx, rcx, rbx, rax;
+    u64_t interrupt, errorCode, rip, cs, rflags, rsp, ss;
+};
 
 inline void pause()
 {

--- a/kernel/kernel/arch/x86_64/gdt.cpp
+++ b/kernel/kernel/arch/x86_64/gdt.cpp
@@ -1,5 +1,6 @@
 #include <kernel/arch/x86_64/gdt.hpp>
 
+#include <kernel/utility/log.hpp>
 #include <ncxx/basic-types.hpp>
 #include <ncxx/preprocessor/packed.hpp>
 
@@ -83,6 +84,8 @@ GDTR gdtr{
 
 void initialize()
 {
+    Log::info("gdt: initialization");
+
     asm volatile(
         "lgdt %[gdtr]\n\t"
         "mov %[dsel], %%ds \n\t"

--- a/kernel/kernel/arch/x86_64/idt.S
+++ b/kernel/kernel/arch/x86_64/idt.S
@@ -1,0 +1,50 @@
+.include "kernel/arch/x86_64/cpu-registers-push-pop.inc"
+
+.extern NOS_interruptHandler
+NOS_InterruptCommonStub:
+    cld
+
+    test qword ptr [rsp + 24], 0x03
+    je 1f
+    swapgs
+1:
+
+    pushall
+    mov rdi, rsp
+    call NOS_interruptHandler
+    popall
+    add rsp, 16
+
+    test qword ptr [rsp + 8], 0x03
+    je 1f
+    swapgs
+1:
+
+    iretq
+
+.macro isr number
+    isr_\number:
+.if !(\number == 8 || (\number >= 10 && \number <= 14) || \number == 17 || \number == 21 || \number == 29 || \number == 30)
+    push 0
+.endif
+    push \number
+    jmp NOS_InterruptCommonStub
+.endm
+
+.altmacro
+.macro isr_insert number
+    .section .text
+    isr \number
+
+    .section .data
+    .quad isr_\number
+.endm
+
+.section .data
+NOS_interruptTable:
+.set i, 0
+.rept 256
+    isr_insert %i
+    .set i, i + 1
+.endr
+.global NOS_interruptTable

--- a/kernel/kernel/arch/x86_64/idt.cpp
+++ b/kernel/kernel/arch/x86_64/idt.cpp
@@ -1,0 +1,138 @@
+#include <kernel/arch/x86_64/idt.hpp>
+
+#include <kernel/arch/x86_64/cpu.hpp>
+#include <kernel/arch/x86_64/gdt.hpp>
+#include <kernel/utility/log.hpp>
+#include <kernel/utility/panic.hpp>
+#include <ncxx/basic-types.hpp>
+#include <ncxx/container/static-array.hpp>
+#include <ncxx/preprocessor/packed.hpp>
+#include <ncxx/string/format.hpp>
+#include <ncxx/string/string-view.hpp>
+
+extern "C" void* NOS_interruptTable[];
+
+namespace NOS::X86_64::IDT {
+
+inline constexpr size_t MaximumEntries = 256;
+
+namespace Data {
+
+struct NOS_PACKED Entry
+{
+    u16_t offset1;
+    u16_t selector;
+    u8_t ist;
+    u8_t typeAttr;
+    u16_t offset2;
+    u32_t offset3;
+    u32_t zero{0};
+
+    void set(void* isr_, uint8_t typeAttr_ = 0x8E, uint8_t ist_ = 0)
+    {
+        u64_t isr = reinterpret_cast<u64_t>(isr_);
+        offset1 = static_cast<u16_t>(isr);
+        selector = GDT::Selector::Code;
+        ist = ist_;
+        typeAttr = typeAttr_;
+        offset2 = static_cast<u16_t>(isr >> 16);
+        offset3 = static_cast<u32_t>(isr >> 32);
+    }
+};
+
+struct NOS_PACKED Register
+{
+    u16_t limit;
+    u64_t base;
+
+    void load()
+    {
+        asm volatile("cli");
+        asm volatile("lidt %0" ::"memory"(*this));
+        asm volatile("sti");
+    }
+};
+
+StaticArray<Entry, MaximumEntries> entries;
+
+Register idtr{
+    .limit = sizeof(Entry) * MaximumEntries - 1,
+    .base = reinterpret_cast<uintptr_t>(entries.data())};
+
+} // namespace Data
+
+constexpr StringView ExceptionMessages[32]{
+    "Division by zero",
+    "Debug",
+    "Non-maskable interrupt",
+    "Breakpoint",
+    "Detected overflow",
+    "Out-of-bounds",
+    "Invalid opcode",
+    "No coprocessor",
+    "Double fault",
+    "Coprocessor segment overrun",
+    "Bad TSS",
+    "Segment not present",
+    "Stack fault",
+    "General protection fault",
+    "Page fault",
+    "Unknown interrupt",
+    "Coprocessor fault",
+    "Alignment check",
+    "Machine check",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+};
+
+void handleException(const CPU::Registers& registers)
+{
+    panic(format("idt: Exception {} on CPU {}", ExceptionMessages[registers.interrupt], 0));
+}
+
+void dispatch(const CPU::Registers& registers)
+{
+    Log::info("idt: dispatch");
+
+    if (registers.interrupt < 32)
+    {
+        handleException(registers);
+    }
+    else if (registers.interrupt >= 32 && registers.interrupt <= MaximumEntries)
+    {
+    }
+    else
+    {
+        panic(format("idt: Unknown interrupt {}", ExceptionMessages[registers.interrupt], 0));
+    }
+}
+
+void initialize()
+{
+    Log::info("idt: initialization");
+
+    for (size_t i = 0; i < Data::entries.size(); ++i)
+    {
+        Data::entries[i].set(NOS_interruptTable[i]);
+    }
+
+    Data::idtr.load();
+}
+
+} // namespace NOS::X86_64::IDT
+
+extern "C" void NOS_interruptHandler(NOS::X86_64::CPU::Registers* registers)
+{
+    NOS::X86_64::IDT::dispatch(*registers);
+}

--- a/kernel/kernel/arch/x86_64/idt.hpp
+++ b/kernel/kernel/arch/x86_64/idt.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace NOS::X86_64::IDT {
+
+void initialize();
+
+} // namespace NOS::X86_64::IDT

--- a/kernel/kernel/kernel.cpp
+++ b/kernel/kernel/kernel.cpp
@@ -1,10 +1,10 @@
 #include <kernel/kernel.hpp>
 
 #include <kernel/arch/arch.hpp>
+#include <kernel/arch/interrupt.hpp>
 #include <kernel/drivers/serial.hpp>
 #include <kernel/lang/cxxabi.hpp>
 #include <kernel/utility/log.hpp>
-#include <ncxx/utility/on-scope-exit.hpp>
 
 namespace NOS::Kernel {
 
@@ -27,6 +27,7 @@ void initialize()
 
 void run()
 {
+    Interrupt::halt();
 }
 
 } // namespace NOS::Kernel

--- a/kernel/kernel/lang/ubsan.cpp
+++ b/kernel/kernel/lang/ubsan.cpp
@@ -107,7 +107,7 @@ struct AlignmentAssumptionData
 
 static void print(StringView message, SourceLocation location)
 {
-    Log::warn("Ubsan: {} at file {}, line {}, column {}", message, location.fileName, location.line, location.column);
+    Log::error("Ubsan: {} at file {}, line {}, column {}", message, location.fileName, location.line, location.column);
     Interrupt::hcf();
 }
 

--- a/kernel/meson.build
+++ b/kernel/meson.build
@@ -14,7 +14,9 @@ src = files(
 if arch == 'x86_64'
     src += files(
         'kernel/arch/x86_64/drivers/serial.cpp',
-        'kernel/arch/x86_64/gdt.cpp'
+        'kernel/arch/x86_64/gdt.cpp',
+        'kernel/arch/x86_64/idt.cpp',
+        'kernel/arch/x86_64/idt.S'
     )
 endif
 


### PR DESCRIPTION
 Created a new file `kernel/kernel/arch/x86_64/cpu-registers-push-pop.inc` for pushing and popping CPU registers
- Added code to push and pop all CPU registers in the interrupt handler in `kernel/kernel/arch/x86_64/idt.S`
- Added a new file `kernel/kernel/arch/x86_64/idt.cpp` for IDT related functions
- Updated the interrupt handling logic in the dispatch function of `kernel/kernel/arch/x86_64/idt.cpp`
- Modified the print function in `kernel/kernel/lang/ubsan.cpp` to log errors instead of warnings
