### PR TITLE
Add branching and naming conventions to documentation

### DIFF
--- a/docs/branching-convention.md
+++ b/docs/branching-convention.md
@@ -1,0 +1,14 @@
+# Branching convention
+
+- bugfix/
+  - Used to fix bug
+- clean-up/
+  - Used for clean-up of code
+- documentation/
+  - Used for adding or improving documentation
+- feature/
+  - Used for new or existing feature 
+- release/
+  - Used for release of the NOS
+- refactor/
+    - Used for refactor of code 

--- a/docs/naming-convention.md
+++ b/docs/naming-convention.md
@@ -6,12 +6,14 @@
     - enum
     - alias
     - namespace
+    - constant
  - camelCase 
     - variable
+    - static variable
     - function
     - method
  - SCREAMING_SNAKE_CASE
-    - macro constant
+    - macro
  - kebab-case
     - file
     - folder


### PR DESCRIPTION
This commit adds a new file, "branching-convention.md", which outlines the different types of branches used in the project. It also updates the "naming-convention.md" file to include a new convention for constants. The conventions are described in detail within each file.

Changes:
- Added "branching-convention.md" with descriptions of bugfix, clean-up, documentation, feature, release, and refactor branches
- Updated "naming-convention.md" to include constant as a naming convention
